### PR TITLE
Typo in Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ the translation is successful.
       }
 
       //start the test
-      lmv.initialise().then(onInitialized, onError);
+      lmv.initialize().then(onInitialized, onError);
 ```
 
 ## Offline


### PR DESCRIPTION
The sample code in the Usage section isn't working because in the last line ```lmv.initialize``` is mistyped.